### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,7 @@ jobs:
   build:
     name: "Build"
     needs: ["test"]
+    if: github.ref == 'refs/heads/master'
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: "Docker"
 
 on:
+  workflow_dispatch:
+
   push:
     branches: ["master"]
 
@@ -11,14 +13,51 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: "Test (${{ matrix.tag }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: bullseye/Dockerfile
+            tag: latest
+          - dockerfile: bookworm/Dockerfile
+            tag: bookworm
+          - dockerfile: bookworm/Dockerfile.slim
+            tag: bookworm-slim
+          - dockerfile: bullseye/Dockerfile
+            tag: bullseye
+          - dockerfile: bullseye/Dockerfile.slim
+            tag: bullseye-slim
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v4
+
+      - name: "Build image"
+        uses: docker/build-push-action@v7
+        with:
+          context: "."
+          file: "${{ matrix.dockerfile }}"
+          load: true
+          tags: "dockette/debian:${{ matrix.tag }}"
+
+      - name: "Test image"
+        run: "make test TAG=${{ matrix.tag }}"
+
   build:
     name: "Build"
+    needs: ["test"]
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:
-        image: "dockette/debian"
-        tag: "${{ matrix.tag }}"
-        dockerfile: "${{ matrix.dockerfile }}"
+      image: "dockette/debian"
+      tag: "${{ matrix.tag }}"
+      dockerfile: "${{ matrix.dockerfile }}"
     strategy:
       max-parallel: 3
       fail-fast: false
@@ -48,3 +87,19 @@ jobs:
           - dockerfile: stretch/Dockerfile.slim
             tag: stretch-slim
 
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/debian"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,34 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Base Debian Docker images for Dockette. Images provide a `dfx` user with UID `1000`, `USER_*` environment constants, `/bin/bash` as the default command, and cleanup for smaller layers.
+
+## Images
+
+- Docker image: `dockette/debian`.
+- Default Makefile build: `bookworm` from `bookworm/Dockerfile` with tag `bookworm`.
+- Supported directories include `sid`, `bookworm`, `bullseye`, `buster`, `stretch`, `jessie`, and `wheezy`.
+- Standard variants use `Dockerfile`; slim variants use `Dockerfile.slim` and tags like `bookworm-slim`.
+- GitHub Actions tests and publishes selected tags, including `latest`, `bookworm`, `bookworm-slim`, `bullseye`, `bullseye-slim`, `buster`, `buster-slim`, `stretch`, and `stretch-slim`.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make build` builds `dockette/debian:${DOCKER_TAG}` from `${DOCKER_VERSION}/Dockerfile`.
+- `make build-bookworm-slim` builds a slim variant by overriding `DOCKER_FILE`.
+- `make test` verifies the `dfx` user, `USER_NAME`, and `/etc/debian_version` inside the image.
+- `make run` opens `/bin/bash` in the selected image.
+- Override `DOCKER_VERSION`, `DOCKER_TAG`, and `DOCKER_FILE` when working on a specific variant.
+
+## Testing
+
+- Use `make -n build test run` to dry-run the default commands before changing build logic.
+- Run the matching `make test-*` target after building any variant that has a test target.
+- Keep Makefile targets and workflow matrix entries aligned when adding, removing, or retagging variants.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep Dockerfiles, `Makefile`, README usage examples, and `.github/workflows/docker.yml` tag matrices aligned.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
-- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Preserve the `dfx` user contract and cleanup pattern unless intentionally changing all variants.
 - Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,77 +1,77 @@
 DOCKER_IMAGE ?= dockette/debian
-VERSION ?= bookworm
-TAG ?= $(VERSION)
-DOCKERFILE ?= $(VERSION)/Dockerfile
+DOCKER_VERSION?=bookworm
+DOCKER_TAG?=${DOCKER_VERSION}
+DOCKER_FILE?=${DOCKER_VERSION}/Dockerfile
 
 build:
-	docker buildx build --pull -t $(DOCKER_IMAGE):$(TAG) -f $(DOCKERFILE) ./$(VERSION)
+	docker buildx build --pull -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f ${DOCKER_FILE} ./${DOCKER_VERSION}
 
 test:
-	docker run --rm $(DOCKER_IMAGE):$(TAG) sh -lc 'test "$$(id -u dfx)" = "1000" && test "$${USER_NAME}" = "dfx" && test -f /etc/debian_version'
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} sh -lc 'test "$$(id -u dfx)" = "1000" && test "$${USER_NAME}" = "dfx" && test -f /etc/debian_version'
 
 run:
-	docker run --rm -it $(DOCKER_IMAGE):$(TAG) /bin/bash
+	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_TAG} /bin/bash
 
-build-sid: VERSION=sid
-build-sid: TAG=sid
+build-sid: DOCKER_VERSION=sid
+build-sid: DOCKER_TAG=sid
 build-sid: build # dev
 
-build-bookworm: VERSION=bookworm
-build-bookworm: TAG=bookworm
+build-bookworm: DOCKER_VERSION=bookworm
+build-bookworm: DOCKER_TAG=bookworm
 build-bookworm: build # 12
 
-build-bookworm-slim: VERSION=bookworm
-build-bookworm-slim: TAG=bookworm-slim
-build-bookworm-slim: DOCKERFILE=bookworm/Dockerfile.slim
+build-bookworm-slim: DOCKER_VERSION=bookworm
+build-bookworm-slim: DOCKER_TAG=bookworm-slim
+build-bookworm-slim: DOCKER_FILE=bookworm/Dockerfile.slim
 build-bookworm-slim: build # 12
 
-test-bookworm: TAG=bookworm
+test-bookworm: DOCKER_TAG=bookworm
 test-bookworm: test # 12
 
-test-bookworm-slim: TAG=bookworm-slim
+test-bookworm-slim: DOCKER_TAG=bookworm-slim
 test-bookworm-slim: test # 12
 
-run-bookworm: TAG=bookworm
+run-bookworm: DOCKER_TAG=bookworm
 run-bookworm: run # 12
 
-run-bookworm-slim: TAG=bookworm-slim
+run-bookworm-slim: DOCKER_TAG=bookworm-slim
 run-bookworm-slim: run # 12
 
-build-bullseye: VERSION=bullseye
-build-bullseye: TAG=bullseye
+build-bullseye: DOCKER_VERSION=bullseye
+build-bullseye: DOCKER_TAG=bullseye
 build-bullseye: build # 11
 
-build-bullseye-slim: VERSION=bullseye
-build-bullseye-slim: TAG=bullseye-slim
-build-bullseye-slim: DOCKERFILE=bullseye/Dockerfile.slim
+build-bullseye-slim: DOCKER_VERSION=bullseye
+build-bullseye-slim: DOCKER_TAG=bullseye-slim
+build-bullseye-slim: DOCKER_FILE=bullseye/Dockerfile.slim
 build-bullseye-slim: build # 11
 
-test-bullseye: TAG=bullseye
+test-bullseye: DOCKER_TAG=bullseye
 test-bullseye: test # 11
 
-test-bullseye-slim: TAG=bullseye-slim
+test-bullseye-slim: DOCKER_TAG=bullseye-slim
 test-bullseye-slim: test # 11
 
-run-bullseye: TAG=bullseye
+run-bullseye: DOCKER_TAG=bullseye
 run-bullseye: run # 11
 
-run-bullseye-slim: TAG=bullseye-slim
+run-bullseye-slim: DOCKER_TAG=bullseye-slim
 run-bullseye-slim: run # 11
 
-build-buster: VERSION=buster
-build-buster: TAG=buster
+build-buster: DOCKER_VERSION=buster
+build-buster: DOCKER_TAG=buster
 build-buster: build # 10
 
-build-stretch: VERSION=stretch
-build-stretch: TAG=stretch
+build-stretch: DOCKER_VERSION=stretch
+build-stretch: DOCKER_TAG=stretch
 build-stretch: build # 9
 
-build-jessie: VERSION=jessie
-build-jessie: TAG=jessie
+build-jessie: DOCKER_VERSION=jessie
+build-jessie: DOCKER_TAG=jessie
 build-jessie: build # 8
 
-build-wheezy: VERSION=wheezy
-build-wheezy: TAG=wheezy
+build-wheezy: DOCKER_VERSION=wheezy
+build-wheezy: DOCKER_TAG=wheezy
 build-wheezy: build # 7
 
 docker-build-sid: build-sid

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,83 @@
-DOCKER_IMAGE=dockette/debian
+DOCKER_IMAGE ?= dockette/debian
+VERSION ?= bookworm
+TAG ?= $(VERSION)
+DOCKERFILE ?= $(VERSION)/Dockerfile
 
-_docker-build-%: VERSION=$*
-_docker-build-%:
-	docker buildx \
-		build \
-		--pull \
-		-t ${DOCKER_IMAGE}:${VERSION} \
-		./${VERSION}
+build:
+	docker buildx build --pull -t $(DOCKER_IMAGE):$(TAG) -f $(DOCKERFILE) ./$(VERSION)
 
-docker-build-sid: _docker-build-sid # dev
-docker-build-bookworm: _docker-build-bookworm # 12
-docker-build-bullseye: _docker-build-bullseye # 11
-docker-build-buster: _docker-build-buster # 10
-docker-build-stretch: _docker-build-stretch # 9
-docker-build-jessie: _docker-build-jessie # 8
-docker-build-wheezy: _docker-build-wheezy # 7
+test:
+	docker run --rm $(DOCKER_IMAGE):$(TAG) sh -lc 'test "$$(id -u dfx)" = "1000" && test "$${USER_NAME}" = "dfx" && test -f /etc/debian_version'
+
+run:
+	docker run --rm -it $(DOCKER_IMAGE):$(TAG) /bin/bash
+
+build-sid: VERSION=sid
+build-sid: TAG=sid
+build-sid: build # dev
+
+build-bookworm: VERSION=bookworm
+build-bookworm: TAG=bookworm
+build-bookworm: build # 12
+
+build-bookworm-slim: VERSION=bookworm
+build-bookworm-slim: TAG=bookworm-slim
+build-bookworm-slim: DOCKERFILE=bookworm/Dockerfile.slim
+build-bookworm-slim: build # 12
+
+test-bookworm: TAG=bookworm
+test-bookworm: test # 12
+
+test-bookworm-slim: TAG=bookworm-slim
+test-bookworm-slim: test # 12
+
+run-bookworm: TAG=bookworm
+run-bookworm: run # 12
+
+run-bookworm-slim: TAG=bookworm-slim
+run-bookworm-slim: run # 12
+
+build-bullseye: VERSION=bullseye
+build-bullseye: TAG=bullseye
+build-bullseye: build # 11
+
+build-bullseye-slim: VERSION=bullseye
+build-bullseye-slim: TAG=bullseye-slim
+build-bullseye-slim: DOCKERFILE=bullseye/Dockerfile.slim
+build-bullseye-slim: build # 11
+
+test-bullseye: TAG=bullseye
+test-bullseye: test # 11
+
+test-bullseye-slim: TAG=bullseye-slim
+test-bullseye-slim: test # 11
+
+run-bullseye: TAG=bullseye
+run-bullseye: run # 11
+
+run-bullseye-slim: TAG=bullseye-slim
+run-bullseye-slim: run # 11
+
+build-buster: VERSION=buster
+build-buster: TAG=buster
+build-buster: build # 10
+
+build-stretch: VERSION=stretch
+build-stretch: TAG=stretch
+build-stretch: build # 9
+
+build-jessie: VERSION=jessie
+build-jessie: TAG=jessie
+build-jessie: build # 8
+
+build-wheezy: VERSION=wheezy
+build-wheezy: TAG=wheezy
+build-wheezy: build # 7
+
+docker-build-sid: build-sid
+docker-build-bookworm: build-bookworm
+docker-build-bullseye: build-bullseye
+docker-build-buster: build-buster
+docker-build-stretch: build-stretch
+docker-build-jessie: build-jessie
+docker-build-wheezy: build-wheezy

--- a/Makefile
+++ b/Makefile
@@ -3,81 +3,108 @@ DOCKER_VERSION?=bookworm
 DOCKER_TAG?=${DOCKER_VERSION}
 DOCKER_FILE?=${DOCKER_VERSION}/Dockerfile
 
+.PHONY: build
 build:
 	docker buildx build --pull -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f ${DOCKER_FILE} ./${DOCKER_VERSION}
 
+.PHONY: test
 test:
 	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} sh -lc 'test "$$(id -u dfx)" = "1000" && test "$${USER_NAME}" = "dfx" && test -f /etc/debian_version'
 
+.PHONY: run
 run:
 	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_TAG} /bin/bash
 
 build-sid: DOCKER_VERSION=sid
 build-sid: DOCKER_TAG=sid
+.PHONY: build-sid
 build-sid: build # dev
 
 build-bookworm: DOCKER_VERSION=bookworm
 build-bookworm: DOCKER_TAG=bookworm
+.PHONY: build-bookworm
 build-bookworm: build # 12
 
 build-bookworm-slim: DOCKER_VERSION=bookworm
 build-bookworm-slim: DOCKER_TAG=bookworm-slim
 build-bookworm-slim: DOCKER_FILE=bookworm/Dockerfile.slim
+.PHONY: build-bookworm-slim
 build-bookworm-slim: build # 12
 
 test-bookworm: DOCKER_TAG=bookworm
+.PHONY: test-bookworm
 test-bookworm: test # 12
 
 test-bookworm-slim: DOCKER_TAG=bookworm-slim
+.PHONY: test-bookworm-slim
 test-bookworm-slim: test # 12
 
 run-bookworm: DOCKER_TAG=bookworm
+.PHONY: run-bookworm
 run-bookworm: run # 12
 
 run-bookworm-slim: DOCKER_TAG=bookworm-slim
+.PHONY: run-bookworm-slim
 run-bookworm-slim: run # 12
 
 build-bullseye: DOCKER_VERSION=bullseye
 build-bullseye: DOCKER_TAG=bullseye
+.PHONY: build-bullseye
 build-bullseye: build # 11
 
 build-bullseye-slim: DOCKER_VERSION=bullseye
 build-bullseye-slim: DOCKER_TAG=bullseye-slim
 build-bullseye-slim: DOCKER_FILE=bullseye/Dockerfile.slim
+.PHONY: build-bullseye-slim
 build-bullseye-slim: build # 11
 
 test-bullseye: DOCKER_TAG=bullseye
+.PHONY: test-bullseye
 test-bullseye: test # 11
 
 test-bullseye-slim: DOCKER_TAG=bullseye-slim
+.PHONY: test-bullseye-slim
 test-bullseye-slim: test # 11
 
 run-bullseye: DOCKER_TAG=bullseye
+.PHONY: run-bullseye
 run-bullseye: run # 11
 
 run-bullseye-slim: DOCKER_TAG=bullseye-slim
+.PHONY: run-bullseye-slim
 run-bullseye-slim: run # 11
 
 build-buster: DOCKER_VERSION=buster
 build-buster: DOCKER_TAG=buster
+.PHONY: build-buster
 build-buster: build # 10
 
 build-stretch: DOCKER_VERSION=stretch
 build-stretch: DOCKER_TAG=stretch
+.PHONY: build-stretch
 build-stretch: build # 9
 
 build-jessie: DOCKER_VERSION=jessie
 build-jessie: DOCKER_TAG=jessie
+.PHONY: build-jessie
 build-jessie: build # 8
 
 build-wheezy: DOCKER_VERSION=wheezy
 build-wheezy: DOCKER_TAG=wheezy
+.PHONY: build-wheezy
 build-wheezy: build # 7
 
+.PHONY: docker-build-sid
 docker-build-sid: build-sid
+.PHONY: docker-build-bookworm
 docker-build-bookworm: build-bookworm
+.PHONY: docker-build-bullseye
 docker-build-bullseye: build-bullseye
+.PHONY: docker-build-buster
 docker-build-buster: build-buster
+.PHONY: docker-build-stretch
 docker-build-stretch: build-stretch
+.PHONY: docker-build-jessie
 docker-build-jessie: build-jessie
+.PHONY: docker-build-wheezy
 docker-build-wheezy: build-wheezy

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
    <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
-Base docker image based on Debian. Special variants for Sid / Jessie / Wheezy.
+Base Docker image based on Debian.
 
 ------
 
@@ -18,37 +18,38 @@ Base docker image based on Debian. Special variants for Sid / Jessie / Wheezy.
     - `USER_UID`: `1000`
     - `USER_NAME`: `dfx`
     - `USER_HOME`: `/home/dfx`
-- some optimalization for smaller image 
+- cleanup and optimization for smaller images
+
+## Tags
+
+The default local build uses `bookworm` from `bookworm/Dockerfile`.
+
+The Makefile provides named standard build targets for directory variants and named slim/test/run targets for `bookworm` and `bullseye`; use `DOCKER_VERSION`, `DOCKER_TAG`, and `DOCKER_FILE` overrides for other slim or manual builds.
+
+CI tests these tags:
+
+- `bookworm`, `bookworm-slim`
+- `bullseye`, `bullseye-slim`
+- `latest` (built from `bullseye/Dockerfile`)
+
+CI also publishes legacy compatibility tags `buster`, `buster-slim`, `stretch`, and `stretch-slim`. These Debian releases are EOL; prefer current tags for new images.
+
+Additional directories exist for `sid`, `jessie`, and `wheezy`, but they are not in the workflow matrix. `jessie` and `wheezy` are EOL and should only be built manually when compatibility requires them.
 
 ## CLI
 
-```
-docker run -it --rm dockette/debian:sid /bin/bash
-docker run -it --rm dockette/debian:sid-slim /bin/bash
-
+```sh
 docker run -it --rm dockette/debian:bookworm /bin/bash
 docker run -it --rm dockette/debian:bookworm-slim /bin/bash
 
 docker run -it --rm dockette/debian:bullseye /bin/bash
 docker run -it --rm dockette/debian:bullseye-slim /bin/bash
-
-docker run -it --rm dockette/debian:buster /bin/bash
-docker run -it --rm dockette/debian:buster-slim /bin/bash
-
-docker run -it --rm dockette/debian:stretch /bin/bash
-docker run -it --rm dockette/debian:stretch-slim /bin/bash
-
-docker run -it --rm dockette/debian:jessie /bin/bash
-docker run -it --rm dockette/debian:jessie-slim /bin/bash
-
-docker run -it --rm dockette/debian:wheezy /bin/bash
-docker run -it --rm dockette/debian:wheezy-slim /bin/bash
 ```
 
 ## Base
 
-```
-FROM dockette/debian:buster-slim
+```Dockerfile
+FROM dockette/debian:bookworm
 
 RUN apt update && apt install -y curl
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Debian
 
+<p align=center>
+   <a href="https://github.com/dockette/debian/actions"><img src="https://github.com/dockette/debian/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/debian"><img src="https://img.shields.io/docker/pulls/dockette/debian.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
 Base docker image based on Debian. Special variants for Sid / Jessie / Wheezy.
 
 ------
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/debian.svg?style=flat)](https://hub.docker.com/r/dockette/debian/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/debian.svg?style=flat)](https://hub.docker.com/r/dockette/debian/)
-
-## Discussion / Help
-
-[![Join the chat](https://img.shields.io/gitter/room/dockette/dockette.svg?style=flat-square)](https://gitter.im/dockette/dockette?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Image
 

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -9,7 +9,10 @@ ENV USER_UID 1000
 ENV USER_NAME dfx
 ENV USER_HOME /home/dfx
 
-RUN apt-get update && \
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive && \
+    echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
+    apt-get update && \
     apt-get dist-upgrade -y && \
     useradd -ms /bin/bash -u $USER_UID $USER_NAME && \
     apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y && \

--- a/buster/Dockerfile.slim
+++ b/buster/Dockerfile.slim
@@ -9,7 +9,10 @@ ENV USER_UID 1000
 ENV USER_NAME dfx
 ENV USER_HOME /home/dfx
 
-RUN apt-get update && \
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive && \
+    echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
+    apt-get update && \
     apt-get dist-upgrade -y && \
     useradd -ms /bin/bash -u $USER_UID $USER_NAME && \
     apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y && \


### PR DESCRIPTION
What changed
- Added a Test job for maintained Debian tags before the reusable Build job.
- Added Docker Hub description publishing via the Docs job.
- Normalized Makefile build/test/run targets and README badges/maintenance links.

Why
- Brings dockette/debian in line with the Dockette CI rollout baseline while preserving the existing build matrix.